### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ LazyData: true
 ByteCompile: true
 Depends: R (>= 3.5.0), methods,Rcpp (>= 1.0.0)
 Imports: 
-  rstan (>= 2.18.2), 
+  rstan (>= 2.26.0), 
   rstantools (>= 2.3.0), 
   magrittr (>= 1.5), 
   dplyr (>= 0.8.0), 
@@ -21,8 +21,8 @@ Imports:
   purrr (>= 0.3.0), 
   ggplot2 (>= 2.2.1)
 LinkingTo: 
-  StanHeaders (>= 2.18.1), 
-  rstan (>= 2.18.2), 
+  StanHeaders (>= 2.26.0), 
+  rstan (>= 2.26.0), 
   BH (>= 1.69.0-1), 
   Rcpp (>= 1.0.0), 
   RcppEigen (>= 0.3.3.5.0), 

--- a/inst/stan/emax.stan
+++ b/inst/stan/emax.stan
@@ -4,9 +4,9 @@ data{
   vector[N] response;
 
   // Covariates
-  int<lower = 1> covemax[N];
-  int<lower = 1> covec50[N];
-  int<lower = 1> cove0[N];
+  array[N] int<lower = 1> covemax;
+  array[N] int<lower = 1> covec50;
+  array[N] int<lower = 1> cove0;
   int<lower = 1> n_covlev_emax;
   int<lower = 1> n_covlev_ec50;
   int<lower = 1> n_covlev_e0;
@@ -37,10 +37,10 @@ data{
 parameters{
   // vector[n_covlev_emax] emax;
   vector<lower = 0>[n_covlev_ec50] ec50;
-  // vector[n_covlev_e0] e0_par[1-e0_fix_flg];
-  real e0_par[n_covlev_e0, 1-e0_fix_flg];
-  real emax_par[n_covlev_emax, 1-emax_fix_flg];
-  real<lower = 0> gamma_par[1-gamma_fix_flg];
+  // array[1-e0_fix_flg] vector[n_covlev_e0] e0_par;
+  array[n_covlev_e0, 1-e0_fix_flg] real e0_par;
+  array[n_covlev_emax, 1-emax_fix_flg] real emax_par;
+  array[1-gamma_fix_flg] real<lower = 0> gamma_par;
 
   real<lower = 0> sigma;
 }


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
