### PR TITLE
add ndraws support for posterior_*() functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,7 @@ Imports:
     ggplot2 (>= 2.2.1),
     posterior,
     boot,
-    lifecycle,
-    tidybayes
+    lifecycle
 LinkingTo: 
     StanHeaders (>= 2.26.0), 
     rstan (>= 2.26.0), 
@@ -43,7 +42,8 @@ Suggests:
     rmarkdown,
     spelling,
     tibble,
-    withr
+    withr,
+    tidybayes
 VignetteBuilder: knitr
 Language: en-US
 URL: https://github.com/yoshidk6/rstanemax, https://yoshidk6.github.io/rstanemax/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,9 @@ Suggests:
     testthat,
     knitr,
     rmarkdown,
-    spelling
+    spelling,
+    tibble,
+    withr
 VignetteBuilder: knitr
 Language: en-US
 URL: https://github.com/yoshidk6/rstanemax, https://yoshidk6.github.io/rstanemax/

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -25,7 +25,9 @@ rstantools::posterior_predict
 #'   whether in the format of an original data frame ("raw", the default) or a
 #'   processed model frame ("modelframe"). Mostly used for internal purposes and
 #'   users can usually leave at default.
-#' @param ... Additional arguments passed to methods.
+#' @param ... Additional arguments passed to methods. Arguments that can be
+#'   passed via the dots include `ndraws`, for compatibility with functions in
+#'   the tidybayes package
 #' @return An object that contain predicted response with posterior distribution
 #'   of parameters. The default is a matrix containing predicted `response` for
 #'   [stan_emax()] and `.epred` for [stan_emax_binary()]. Each row of the matrix

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -195,6 +195,7 @@ posterior_linpred.stanemaxbin <- function(object,
                                newdata,
                                returnType,
                                newDataType,
+                               ndraws = NULL,
                                ...) {
   returnType <- match.arg(returnType, c("matrix", "dataframe", "tibble"))
   newDataType <- match.arg(newDataType, c("raw", "modelframe"))
@@ -203,7 +204,8 @@ posterior_linpred.stanemaxbin <- function(object,
     stanfit = object$stanfit,
     df.model = df.model,
     mod_type = class(object),
-    transform = transform
+    transform = transform,
+    ndraws = ndraws
   )
   pred.response <- pp_update_cov_levels(pred.response.raw, df.model)
   if (returnType == "matrix") {

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -236,10 +236,21 @@ pp_model_frame <- function(object, newdata, newDataType) {
 pp_calc <- function(stanfit,
                     df.model,
                     mod_type = c("stanemax", "stanemaxbin"),
-                    transform = FALSE) {
+                    transform = FALSE,
+                    ndraws = NULL) {
 
   mod_type <- match.arg(mod_type)
   param.fit <- extract_param_fit(stanfit, mod_type)
+
+  if (is.null(ndraws)) {
+    draw_inds <- 1:max(param.fit$mcmcid)
+  } else {
+    draw_inds <- sample(
+      x = max(param.fit$mcmcid),
+      size = ndraws,
+      replace = FALSE
+    )
+  }
 
   df <-
     df.model %>%
@@ -248,7 +259,7 @@ pp_calc <- function(stanfit,
       covec50 = as.numeric(covec50),
       cove0 = as.numeric(cove0)
     ) %>%
-    tidyr::expand_grid(mcmcid = 1:max(param.fit$mcmcid), .) %>%
+    tidyr::expand_grid(mcmcid = draw_inds, .) %>%
     dplyr::left_join(param.fit, by = c("mcmcid", "covemax", "covec50", "cove0"))
 
   if (mod_type == "stanemax") {

--- a/man/posterior_predict.Rd
+++ b/man/posterior_predict.Rd
@@ -60,7 +60,9 @@ posterior_predict_quantile(
 \arguments{
 \item{object}{A \code{stanemax} or \code{stanemaxbin} object}
 
-\item{...}{Additional arguments passed to methods.}
+\item{...}{Additional arguments passed to methods. Arguments that can be
+passed via the dots include \code{ndraws}, for compatibility with functions in
+the tidybayes package}
 
 \item{newdata}{An optional data frame that contains columns needed for model
 to run (exposure and covariates). If the model does not have any covariate,

--- a/tests/testthat/test-tidybayes_integration.R
+++ b/tests/testthat/test-tidybayes_integration.R
@@ -24,7 +24,49 @@ test_that("spread_draws() works", {
   expect_equal(nrow(out), 3000L)
 })
 
+test_that("add_epred_draws() works", {
 
+  for (ndraws in 1L:3L) {
+    for (seed in 1L:3L) {
+
+      # construct expected result manually
+      draw_rows <- expand.grid(
+        .draw = 1L:ndraws,
+        .row = 1L:nrow(exposure.response.sample.with.cov)
+      )
+      d1 <- exposure.response.sample.with.cov |>
+        dplyr::mutate(.row = dplyr::row_number()) |>
+        dplyr::left_join(
+          tibble::tibble(
+            .row = draw_rows$.row,
+            .chain = NA_integer_,
+            .iteration = NA_integer_,
+            .draw = draw_rows$.draw,
+            .epred = as.vector(
+              withr::with_seed(
+                seed = seed,
+                code = posterior_epred(mod, ndraws = ndraws)
+              )
+            )
+          ),
+          by = ".row"
+        )
+
+      # construct with tidybayes and drop grouping
+      d2 <- tidybayes::add_epred_draws(
+        newdata = exposure.response.sample.with.cov,
+        object = mod,
+        ndraws = ndraws,
+        seed = seed
+      ) |>
+        dplyr::ungroup()
+
+      expect_equal(d2, d1)
+    }
+  }
+
+
+})
 
 
 


### PR DESCRIPTION
Adds support for the `ndraws` argument in `tidybayes::add_epred_draws()`, and confirms that the `seed` argument also works when a stanemax object is passed. The changes are all internal, handled by the `.posterior_predict()` and `pp_calc()` functions: there's no outward change to the API for the `posterior_*()` functions (and hence no documentation update), but `tidybayes::add_epred_draws()` is now able to pass the `ndraws` argument via the dots to yield the desired behaviour. The unit test for this also checks that `seed` works as expected. 

Closes #60 